### PR TITLE
Updates to template comments

### DIFF
--- a/templates/newtheme.svg
+++ b/templates/newtheme.svg
@@ -4,16 +4,16 @@
   <!-- Foreground -->
   <circle cx='24' cy='24' r='8' id='f_high'    fill='#ffffff'></circle><!-- main text -->
   <circle cx='40' cy='24' r='8' id='f_med'     fill='#00ffff'></circle><!-- tape logo -->
-  <circle cx='56' cy='24' r='8' id='f_low'     fill='#000000'></circle><!-- unused -->
+  <circle cx='56' cy='24' r='8' id='f_low'     fill='#000000'></circle><!-- item separator -->
   <circle cx='72' cy='24' r='8' id='f_inv'     fill='#ffffff'></circle><!-- groove text -->
   <!-- Background -->
-  <circle cx='24' cy='40' r='8' id='b_high'    fill='#00FFFF'></circle><!-- unused -->
+  <circle cx='24' cy='40' r='8' id='b_high'    fill='#00FFFF'></circle><!-- alt text -->
   <circle cx='40' cy='40' r='8' id='b_med'     fill='#bbbbbb'></circle><!-- groove -->
   <circle cx='56' cy='40' r='8' id='b_low'     fill='#aaaaaa'></circle><!-- collection bg -->
-  <circle cx='72' cy='40' r='8' id='b_inv'     fill='#ff0000'></circle><!-- ramma  -->
+  <circle cx='72' cy='40' r='8' id='b_inv'     fill='#ff0000'></circle><!-- unused  -->
   <!-- Tape -->
   <desc id='tape_style'                        fill='0'></desc><!-- style -->
-  <desc id='tape_priority'                     fill='#ff0000'></desc><!--  -->
+  <desc id='tape_priority'                     fill='#00ffff'></desc><!--  -->
   <desc id='tape_working'                      fill='#00ffff'></desc><!--  -->
   <desc id='tape_submitted'                    fill='#0000ff'></desc><!--  -->
   <desc id='tape_approved'                     fill='#ff00ff'></desc><!--  -->

--- a/templates/newtheme.svg
+++ b/templates/newtheme.svg
@@ -13,7 +13,7 @@
   <circle cx='72' cy='40' r='8' id='b_inv'     fill='#ff0000'></circle><!-- unused  -->
   <!-- Tape -->
   <desc id='tape_style'                        fill='0'></desc><!-- style -->
-  <desc id='tape_priority'                     fill='#00ffff'></desc><!--  -->
+  <desc id='tape_priority'                     fill='#ff0000'></desc><!--  -->
   <desc id='tape_working'                      fill='#00ffff'></desc><!--  -->
   <desc id='tape_submitted'                    fill='#0000ff'></desc><!--  -->
   <desc id='tape_approved'                     fill='#ff00ff'></desc><!--  -->


### PR DESCRIPTION
Updates comments in `newtheme.svg` template, tested against v1.4.0

- `f_low`: from "unused" to "item split"
- `b_high`: from "unused" to "alt text"
- `b_inv`: from "ramma" to "unused"
  - during testing I didn't see any impact from `b_inv`